### PR TITLE
Update decoder.go

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -10,6 +10,7 @@ import (
 	"mime/quotedprintable"
 
 	"github.com/paulrosania/go-charset/charset"
+	_ "github.com/paulrosania/go-charset/charset/data"
 )
 
 func UTF8(cs string, data []byte) ([]byte, error) {


### PR DESCRIPTION
@vjeantet  To avoid `cannot open "charsets.json"` , because the address is hardcoded in https://github.com/paulrosania/go-charset/blob/master/charset/file.go

Cf. comment in https://github.com/paulrosania/go-charset/blob/master/charset/charset.go